### PR TITLE
Interactor model

### DIFF
--- a/lib/ex_machina/errors.rb
+++ b/lib/ex_machina/errors.rb
@@ -1,0 +1,5 @@
+module ExMachina
+  class InvalidTransition < Exception; end
+  class TransitionError < Exception; end
+end
+

--- a/lib/ex_machina/event/validations.rb
+++ b/lib/ex_machina/event/validations.rb
@@ -14,6 +14,10 @@ module ExMachina
           errors << "No transitions defined from '#{status}' status"
         end
       end
+      def validate!
+        validate
+        raise InvalidTransition, error_messages unless valid?
+      end
       def error_messages
         errors.join(", ")
       end


### PR DESCRIPTION
Events are refactored to always return a `Execution` object that respond to: `success?`, `errors`, `current`, `previous`

Machine event methods only return true/false or raise errors using `!` event variant
